### PR TITLE
Fixed wrapping issue.

### DIFF
--- a/rosplane/src/estimator_example.cpp
+++ b/rosplane/src/estimator_example.cpp
@@ -338,7 +338,7 @@ void estimator_example::estimate(const params_s &params, const input_s &input, o
   }
 
   bool problem = false;
-//  int prob_index;
+  int prob_index;
   for (int i = 0; i < 7; i++)
   {
     if (!std::isfinite(xhat_p_(i)))
@@ -346,7 +346,7 @@ void estimator_example::estimate(const params_s &params, const input_s &input, o
       if (!problem)
       {
         problem = true;
-//        prob_index = i;
+        prob_index = i;
       }
       switch (i)
       {
@@ -380,7 +380,7 @@ void estimator_example::estimate(const params_s &params, const input_s &input, o
   }
   if (problem)
   {
-//    RCLCPP_WARN(this->get_logger(), "position estimator reinitialized due to non-finite state %d", prob_index); TODO come back and track down why pn is going infinite.
+    RCLCPP_WARN(this->get_logger(), "position estimator reinitialized due to non-finite state %d", prob_index);
   }
   if (xhat_p_(6) - xhat_p_(3) > radians(360.0f) || xhat_p_(6) - xhat_p_(3) < radians(-360.0f))
   {
@@ -395,9 +395,6 @@ void estimator_example::estimate(const params_s &params, const input_s &input, o
   float wnhat = xhat_p_(4);
   float wehat = xhat_p_(5);
   float psihat = xhat_p_(6);
-
-
-//    RCLCPP_INFO_STREAM(this->get_logger(), "chihat: " << chihat);
 
   output.pn = pnhat;
   output.pe = pehat;

--- a/rosplane/src/estimator_example.cpp
+++ b/rosplane/src/estimator_example.cpp
@@ -293,9 +293,7 @@ void estimator_example::estimate(const params_s &params, const input_s &input, o
     //wrap course measurement
     float gps_course = fmodf(input.gps_course, radians(360.0f));
 
-    xhat_p_(3) = wrap(xhat_p_(3), gps_course);
-    // while (gps_course - xhat_p_(3) > radians(180.0f)) gps_course = gps_course - radians(360.0f);
-    // while (gps_course - xhat_p_(3) < radians(-180.0f)) gps_course = gps_course + radians(360.0f);
+    xhat_p_(3) = wrap_within_180(xhat_p_(3), gps_course);
     h_p_ = xhat_p_(3);
 
     C_p_ = Eigen::VectorXf::Zero(7);

--- a/rosplane/src/estimator_example.cpp
+++ b/rosplane/src/estimator_example.cpp
@@ -86,8 +86,8 @@ void estimator_example::estimate(const params_s &params, const input_s &input, o
   }
 
   // low pass filter gyros to estimate angular rates
-  lpf_gyro_x_ = input.gyro_x;
-  lpf_gyro_y_ = input.gyro_y; // alpha_*lpf_gyro_y_ + (1 - alpha_)*input.gyro_y;
+  lpf_gyro_x_ = alpha_*lpf_gyro_x_ + (1 - alpha_)*input.gyro_x;
+  lpf_gyro_y_ = alpha_*lpf_gyro_y_ + (1 - alpha_)*input.gyro_y;
   lpf_gyro_z_ = alpha_*lpf_gyro_z_ + (1 - alpha_)*input.gyro_z;
 
   float phat = lpf_gyro_x_;

--- a/rosplane/src/estimator_example.cpp
+++ b/rosplane/src/estimator_example.cpp
@@ -9,7 +9,7 @@ float radians(float degrees)
   return M_PI*degrees/180.0;
 }
 
-double wrap(double fixed_heading, double wrapped_heading) {
+double wrap_within_180(double fixed_heading, double wrapped_heading) {
     // wrapped_heading - number_of_times_to_wrap * 2pi
     return wrapped_heading - floor((wrapped_heading - fixed_heading) / (2 * M_PI) + 0.5) * 2 * M_PI;
 }
@@ -243,18 +243,14 @@ void estimator_example::estimate(const params_s &params, const input_s &input, o
     P_p_ = (A_d_*P_p_*A_d_.transpose() + Q_p_*pow(params.Ts/N_, 2));
   }
     
-    xhat_p_(3) = wrap(0.0, xhat_p_(3));
-    // while(xhat_p_(3) > radians(180.0f)) xhat_p_(3) = xhat_p_(3) - radians(360.0f);
-    // while(xhat_p_(3) < radians(-180.0f)) xhat_p_(3) = xhat_p_(3) + radians(360.0f);
+    xhat_p_(3) = wrap_within_180(0.0, xhat_p_(3));
     if(xhat_p_(3) > radians(180.0f) || xhat_p_(3) < radians(-180.0f))
     {
         RCLCPP_WARN(this->get_logger(), "Course estimate not wrapped from -pi to pi");
         xhat_p_(3) = 0;
     }
 
-    xhat_p_(6) = wrap(0.0, xhat_p_(6));
-    // while(xhat_p_(6) > radians(180.0f)) xhat_p_(6) = xhat_p_(6) - radians(360.0f);
-    // while(xhat_p_(6) < radians(-180.0f)) xhat_p_(6) = xhat_p_(6) + radians(360.0f);
+    xhat_p_(6) = wrap_within_180(0.0, xhat_p_(6));
     if(xhat_p_(6) > radians(180.0f) || xhat_p_(6) < radians(-180.0f))
     {
         RCLCPP_WARN(this->get_logger(), "Psi estimate not wrapped from -pi to pi");


### PR DESCRIPTION
This fixes the wrapping issues we have seen in the estimator that cause it to stall indefinitely. We replaced the while loops used to calculate the wrapping to a single execution that calculates the number of wraps required and then applies them. This prevents the stalling.