### PR TITLE
added clang-format file and script

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -33,7 +33,7 @@ BraceWrapping:
   SplitEmptyRecord: true
 BreakBeforeBinaryOperators: NonAssignment
 BreakBeforeTernaryOperators: true
-BreakConstructorInitializers: BeforeColon
+BreakConstructorInitializers: BeforeComma
 BreakInheritanceList: BeforeColon
 ColumnLimit: 100
 CompactNamespaces: false

--- a/fix_code_style.sh
+++ b/fix_code_style.sh
@@ -6,9 +6,9 @@ SCRIPTPATH=`dirname $SCRIPT`
 cd $SCRIPTPATH
 
 # Find all files with ".hpp" or ".cpp" extensions in the current directory and subdirectories,
-# excluding certain paths (.rosflight/include/mavlink/v1.0/, ./rosflight_firmware/firmware/, and ./.git)
+# excluding certain paths (./.git)
 find . -iname "*.hpp" -o -iname "*.cpp" | \
-egrep -v "^(.rosflight/include/mavlink/v1.0/|./rosflight_firmware/firmware/|./.git)" | \
+grep -Ev "^(./.git)" | \
 
 # Format the files according to the rules specified in .clang-format
 xargs clang-format -i


### PR DESCRIPTION
Copied the .clang-format and fix_code_style.sh script from ros_pkgs repo. I didn't include the workflow since requiring that all pull requests comply with the .clang-format file has been more of a pain that it has been helpful. Better to run clang-format on occasion and check that all of it's changes make sense.
