### PR TITLE
Added functionality to check architecture for rosplane_sim

### DIFF
--- a/rosplane_sim/CMakeLists.txt
+++ b/rosplane_sim/CMakeLists.txt
@@ -18,6 +18,11 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
+# Gazebo doesn't have an arm64 target. If host architecture is arm64, skip
+if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "aarch64")
+  return()
+endif()
+
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)


### PR DESCRIPTION
Added check to the CMakeLists of the rosplane_sim package to check if the architecture is arm64. Will skip compilation if it is, so that it doesn't break.