### PR TITLE
46 seeding estimator

### DIFF
--- a/rosplane/CMakeLists.txt
+++ b/rosplane/CMakeLists.txt
@@ -98,6 +98,9 @@ add_executable(rosplane_estimator_node
               src/estimator_base.cpp
               src/estimator_example.cpp
               src/param_manager.cpp)
+target_link_libraries(rosplane_estimator_node
+  ${YAML_CPP_LIBRARIES}
+)
 ament_target_dependencies(rosplane_estimator_node rosplane_msgs rosflight_msgs rclcpp Eigen3)
 install(TARGETS
         rosplane_estimator_node

--- a/rosplane/include/controller_base.hpp
+++ b/rosplane/include/controller_base.hpp
@@ -12,8 +12,7 @@
 
 #include <chrono>
 #include <cstring>
-#include <iostream>
-#include <variant>
+#include <ament_index_cpp/get_package_share_directory.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <rosflight_msgs/msg/command.hpp>
 #include <rosplane_msgs/msg/controller_commands.hpp>

--- a/rosplane/include/estimator_base.hpp
+++ b/rosplane/include/estimator_base.hpp
@@ -108,9 +108,12 @@ private:
   void imuCallback(const sensor_msgs::msg::Imu::SharedPtr msg);
   void baroAltCallback(const rosflight_msgs::msg::Barometer::SharedPtr msg);
   /**
-   * @brief Saves the barometer calibration for future use.
+   * @brief This saves parameters to the param file for later use.
+   *
+   * @param param_name The name of the parameter.
+   * @param param_val The value of the parameter.
    */
-  void saveBaroCalibration();
+  void saveParameter(std::string param_name, double param_val);
   void airspeedCallback(const rosflight_msgs::msg::Airspeed::SharedPtr msg);
   void statusCallback(const rosflight_msgs::msg::Status::SharedPtr msg);
 

--- a/rosplane/include/estimator_base.hpp
+++ b/rosplane/include/estimator_base.hpp
@@ -89,6 +89,7 @@ protected:
   double init_lat_ = 0.0;                 /**< Initial latitude in degrees */
   double init_lon_ = 0.0;                 /**< Initial longitude in degrees */
   float init_alt_ = 0.0;                  /**< Initial altitude in meters above MSL  */
+  float init_static_;                     /**< Initial static pressure (mbar)  */
 
 private:
   rclcpp::Publisher<rosplane_msgs::msg::State>::SharedPtr vehicle_state_pub_;
@@ -129,7 +130,6 @@ private:
 
   bool gps_new_;
   bool armed_first_time_;                 /**< Arm before starting estimation  */
-  float init_static_;                     /**< Initial static pressure (mbar)  */
   int baro_count_;                        /**< Used to grab the first set of baro measurements */
   std::vector<float> init_static_vector_; /**< Used to grab the first set of baro measurements */
 

--- a/rosplane/include/estimator_base.hpp
+++ b/rosplane/include/estimator_base.hpp
@@ -13,7 +13,8 @@
 #include <chrono>
 #include <geometry_msgs/msg/twist_stamped.hpp>
 #include <math.h>
-#include <numeric>
+#include <yaml-cpp/yaml.h>
+#include <ament_index_cpp/get_package_share_directory.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <rosflight_msgs/msg/airspeed.hpp>
 #include <rosflight_msgs/msg/barometer.hpp>
@@ -99,11 +100,17 @@ private:
   rclcpp::Subscription<rosflight_msgs::msg::Airspeed>::SharedPtr airspeed_sub_;
   rclcpp::Subscription<rosflight_msgs::msg::Status>::SharedPtr status_sub_;
 
+  std::string param_filepath_ = "estimator_params.yaml";
+
   void update();
   void gnssFixCallback(const sensor_msgs::msg::NavSatFix::SharedPtr msg);
   void gnssVelCallback(const geometry_msgs::msg::TwistStamped::SharedPtr msg);
   void imuCallback(const sensor_msgs::msg::Imu::SharedPtr msg);
   void baroAltCallback(const rosflight_msgs::msg::Barometer::SharedPtr msg);
+  /**
+   * @brief Saves the barometer calibration for future use.
+   */
+  void saveBaroCalibration();
   void airspeedCallback(const rosflight_msgs::msg::Airspeed::SharedPtr msg);
   void statusCallback(const rosflight_msgs::msg::Status::SharedPtr msg);
 

--- a/rosplane/include/estimator_example.hpp
+++ b/rosplane/include/estimator_example.hpp
@@ -14,7 +14,7 @@ class estimator_example : public estimator_base
 {
 public:
   estimator_example();
-  estimator_example(float init_lat, float init_long, float init_alt);
+  estimator_example(bool use_params);
 
 private:
   virtual void estimate(const input_s & input, output_s & output);

--- a/rosplane/include/estimator_example.hpp
+++ b/rosplane/include/estimator_example.hpp
@@ -5,6 +5,7 @@
 
 #include <Eigen/Geometry>
 #include <math.h>
+#include <yaml-cpp/yaml.h>
 
 namespace rosplane
 {

--- a/rosplane/launch/rosplane.launch.py
+++ b/rosplane/launch/rosplane.launch.py
@@ -22,13 +22,6 @@ def generate_launch_description():
         
         if arg.startswith("seed_estimator:="):
             use_params = arg.split(":=")[1].lower()
-
-            print(use_params)
-
-            if use_params != 'true' and use_params != 'false':
-                print('Not a valid value for seed_estimator. Enter true or false.')
-                print('Defaulting to false.')
-                use_params = 'false'
     
     autopilot_params = os.path.join(
         rosplane_dir,

--- a/rosplane/launch/rosplane.launch.py
+++ b/rosplane/launch/rosplane.launch.py
@@ -11,10 +11,7 @@ def generate_launch_description():
     # Determine the appropriate control scheme.
     control_type = "default"
     aircraft = "skyhunter" # Default aircraft 
-    init_lat = "0.0" # init lat if seeding the estimator (typically not done)
-    init_long = "0.0"
-    init_alt = "0.0"
-    init_baro_alt = "0.0"
+    use_params = 'false'
 
     for arg in sys.argv:
         if arg.startswith("control_type:="):
@@ -23,20 +20,15 @@ def generate_launch_description():
         if arg.startswith("aircraft:="):
             aircraft = arg.split(":=")[1]
         
-        if arg.startswith("init_lat:="):
-            init_lat = float(arg.split(":=")[1])
-            assert isinstance(init_lat, float)
-            init_lat = str(init_lat)
+        if arg.startswith("seed_estimator:="):
+            use_params = arg.split(":=")[1].lower()
 
-        if arg.startswith("init_long:="):
-            init_long = float(arg.split(":=")[1])
-            assert isinstance(init_long, float)
-            init_long = str(init_long)
+            print(use_params)
 
-        if arg.startswith("init_alt:="):
-            init_alt = float(arg.split(":=")[1])
-            assert isinstance(init_alt, float)
-            init_alt = str(init_alt)
+            if use_params != 'true' and use_params != 'false':
+                print('Not a valid value for seed_estimator. Enter true or false.')
+                print('Defaulting to false.')
+                use_params = 'false'
     
     autopilot_params = os.path.join(
         rosplane_dir,
@@ -76,6 +68,6 @@ def generate_launch_description():
             name='estimator',
             output='screen',
             parameters = [autopilot_params],
-            arguments = [init_lat, init_long, init_alt, init_baro_alt]
+            arguments = [use_params]
         )
     ])

--- a/rosplane/params/anaconda_autopilot_params.yaml
+++ b/rosplane/params/anaconda_autopilot_params.yaml
@@ -69,6 +69,7 @@ estimator:
     gps_n_lim: 10000.
     gps_e_lim: 10000.
     frequency: 100
+    # These will be overridden on each boot the workspace is symlink installed.
     baro_calibration_val: 0.0
     init_lat: 0.0
     init_lon: 0.0

--- a/rosplane/params/anaconda_autopilot_params.yaml
+++ b/rosplane/params/anaconda_autopilot_params.yaml
@@ -1,4 +1,4 @@
-autopilot: # node name.
+autopilot:
   ros__parameters:
     alt_hz: 10.0
     alt_toz: 5.0
@@ -31,7 +31,7 @@ autopilot: # node name.
     trim_t: 0.5
     max_e: 0.61
     max_a: 0.60
-    max_r: 0.523  # TODO: Was hardcoded as 1.0 in code...
+    max_r: 0.523
     max_t: 1.0
     pwm_rad_e: 1.0
     pwm_rad_a: 1.0
@@ -41,7 +41,6 @@ autopilot: # node name.
     gravity: 9.8
     max_roll: 35.0
     controller_output_frequency: 100.0
-
 path_manager:
   ros__parameters:
     R_min: 100.0
@@ -49,7 +48,6 @@ path_manager:
     default_altitude: 50.0
     default_airspeed: 25.0
     current_path_pub_frequency: 100.0
-
 path_follower:
   ros__parameters:
     controller_commands_pub_frequency: 10.0
@@ -57,7 +55,6 @@ path_follower:
     k_orbit: 4.0
     k_path: 0.05
     gravity: 9.81
-
 estimator:
   ros__parameters:
     rho: 1.225
@@ -72,3 +69,4 @@ estimator:
     gps_n_lim: 10000.
     gps_e_lim: 10000.
     frequency: 100
+    baro_calibration_val: 0.0

--- a/rosplane/params/anaconda_autopilot_params.yaml
+++ b/rosplane/params/anaconda_autopilot_params.yaml
@@ -70,3 +70,6 @@ estimator:
     gps_e_lim: 10000.
     frequency: 100
     baro_calibration_val: 0.0
+    init_lat: 0.0
+    init_lon: 0.0
+    init_alt: 0.0

--- a/rosplane/src/estimator_base.cpp
+++ b/rosplane/src/estimator_base.cpp
@@ -6,7 +6,6 @@
 #include <fstream>
 #include <iostream>
 #include <rclcpp/logging.hpp>
-//#include <sensor_msgs/nav_sat_status.hpp>
 
 namespace rosplane
 {
@@ -330,14 +329,11 @@ int main(int argc, char ** argv)
   
   rclcpp::init(argc, argv);
 
-  double init_lat = std::atof(argv[1]);
-  double init_long = std::atof(argv[2]);
-  double init_alt = std::atof(argv[3]);
+  char* use_params = argv[1];
 
-
-  if (init_lat != 0.0 || init_long != 0.0 || init_alt != 0.0)
+  if (!strcmp(use_params, "true"))
   {
-    rclcpp::spin(std::make_shared<rosplane::estimator_example>(init_lat, init_long, init_alt));
+    rclcpp::spin(std::make_shared<rosplane::estimator_example>(use_params));
   }
 
   rclcpp::spin(std::make_shared<rosplane::estimator_example>());

--- a/rosplane/src/estimator_base.cpp
+++ b/rosplane/src/estimator_base.cpp
@@ -2,6 +2,7 @@
 #include "estimator_example.hpp"
 #include <cstdlib>
 #include <ament_index_cpp/get_package_share_directory.hpp>
+#include <cstring>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
@@ -182,7 +183,6 @@ void estimator_base::gnssFixCallback(const sensor_msgs::msg::NavSatFix::SharedPt
     return;
   }
   if (!gps_init_ && has_fix) {
-    RCLCPP_INFO_STREAM(this->get_logger(), "init_lat: " << msg->latitude);
     gps_init_ = true;
     init_alt_ = msg->altitude;
     init_lat_ = msg->latitude;
@@ -335,8 +335,17 @@ int main(int argc, char ** argv)
   {
     rclcpp::spin(std::make_shared<rosplane::estimator_example>(use_params));
   }
+  else if(strcmp(use_params, "false")) // If the string is not true or false print error.
+  {
+    auto estimator_node = std::make_shared<rosplane::estimator_example>();
+    RCLCPP_WARN(estimator_node->get_logger(), "Invalid option for seeding estimator, defaulting to unseeded.");
+    rclcpp::spin(estimator_node);
+  }
+  else 
+  {
+    rclcpp::spin(std::make_shared<rosplane::estimator_example>());
+  }
 
-  rclcpp::spin(std::make_shared<rosplane::estimator_example>());
 
   return 0;
 }

--- a/rosplane/src/estimator_example.cpp
+++ b/rosplane/src/estimator_example.cpp
@@ -1,6 +1,5 @@
 #include "estimator_example.hpp"
 #include "estimator_base.hpp"
-#include <rclcpp/logging.hpp>
 
 namespace rosplane
 {
@@ -65,7 +64,6 @@ estimator_example::estimator_example(float init_lat, float init_long, float init
   init_lat_ = init_lat;
   init_lon_ = init_long;
   init_alt_ = init_alt;
-
 }
 
 void estimator_example::initialize_state_covariances() {

--- a/rosplane/src/estimator_example.cpp
+++ b/rosplane/src/estimator_example.cpp
@@ -54,8 +54,13 @@ estimator_example::estimator_example()
   N_ = params.get_int("num_propagation_steps");
 }
 
-estimator_example::estimator_example(float init_lat, float init_long, float init_alt) : estimator_example()
+estimator_example::estimator_example(bool use_params) : estimator_example()
 {
+  double init_lat = params.get_double("init_lat");
+  double init_long = params.get_double("init_lon");
+  double init_alt = params.get_double("init_alt");
+  double init_static = params.get_double("baro_calibration_val");
+
   RCLCPP_INFO_STREAM(this->get_logger(), "init_lat: " << init_lat);
   RCLCPP_INFO_STREAM(this->get_logger(), "init_long: " << init_long);
   RCLCPP_INFO_STREAM(this->get_logger(), "init_alt: " << init_alt);
@@ -64,6 +69,9 @@ estimator_example::estimator_example(float init_lat, float init_long, float init
   init_lat_ = init_lat;
   init_lon_ = init_long;
   init_alt_ = init_alt;
+
+  baro_init_ = true;
+  init_static_ = init_static;
 }
 
 void estimator_example::initialize_state_covariances() {

--- a/rosplane/src/estimator_example.cpp
+++ b/rosplane/src/estimator_example.cpp
@@ -61,9 +61,11 @@ estimator_example::estimator_example(bool use_params) : estimator_example()
   double init_alt = params.get_double("init_alt");
   double init_static = params.get_double("baro_calibration_val");
 
-  RCLCPP_INFO_STREAM(this->get_logger(), "init_lat: " << init_lat);
-  RCLCPP_INFO_STREAM(this->get_logger(), "init_long: " << init_long);
-  RCLCPP_INFO_STREAM(this->get_logger(), "init_alt: " << init_alt);
+  RCLCPP_INFO_STREAM(this->get_logger(), "Using seeded estimator values.");
+  RCLCPP_INFO_STREAM(this->get_logger(), "Seeded initial latitude: " << init_lat);
+  RCLCPP_INFO_STREAM(this->get_logger(), "Seeded initial longitude: " << init_long);
+  RCLCPP_INFO_STREAM(this->get_logger(), "Seeded initial altitude: " << init_alt);
+  RCLCPP_INFO_STREAM(this->get_logger(), "Seeded barometer calibration value: " << init_static);
 
   gps_init_ = true;
   init_lat_ = init_lat;


### PR DESCRIPTION
The estimator now saves the calibration of each of the initialization for lat, lon, alt and baro reading in the parameters file. You can now pass an argument to the estimator node individually or the launch file as a whole, that will allow you to boot using the saved initialization rather than calibrating again.
