### PR TITLE
service calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ To run ROSplane in simulation do the following:
 1. Launch Gazebo and firmware simulation with `ros2 launch rosflight_sim fixedwing.launch.py`
 
 2. Next, run the rosflight_io node configured for SIL with `ros2 run rosflight_io rosflight_io --ros-args -p udp:=true`
-3. Update the firmware parameters for fixedwing flight with `ros2 service call /param_load_from_file rosflight_msgs/srv/ParamFile "filename: rosflight2/rosflight_utils/params/fixedwing_param.yml"` if this is the first time launching.
+3. Update the firmware parameters for fixedwing flight with `ros2 service call /param_load_from_file rosflight_msgs/srv/ParamFile "filename: rosflight/rosflight_sim/params/fixedwing_firmware.yaml"` if this is the first time launching.
 4. Write the new parameters to memory for convenience with `ros2 service call /param_write std_srvs/srv/Trigger`
    - Note: the firmware will time out and not allow takeoff after 100 seconds, so you may need to redo steps one and two.
 5. Calibrate the IMU to allow the airplane to be armed with `ros2 service call /calibrate_imu std_srvs/srv/Trigger`
 6. Then launch ROSplane with `ros2 launch rosplane_sim sim.launch.py`, this will run with the default controller. To use the total energy controller add the argument `control_type:=total_energy`.
 7. Connect a controller with `ros2 run rosflight_utils rc_joy.py --ros-args --remap /RC:=/fixedwing/RC` or if you do not want to use a controller, run `python3 rc_sim.py --ros-args --remap RC:=/fixedwing/RC` while inside `rosflight2/rosflight_utils/src`.
-8. Finally, arm the aircraft with channel 4 and then disable throttle and attitude override with channel 5. If not using a controller use `ros2 service call /arm std_srvs/srv/Trigger` and then disable RC override with `ros2 service call /disable_override std_srvs/srv/Trigger`.
+8. Finally, arm the aircraft with channel 4 and then disable throttle and attitude override with channel 5. If not using a controller use `ros2 service call /toggle_arm std_srvs/srv/Trigger` and then disable RC override with `ros2 service call /toggle_overide std_srvs/srv/Trigger`.
 9. The aircraft should now be airborne!
 
 ## Running ROSplane on hardware.


### PR DESCRIPTION
The service calls in the README.md were for an older version, changed them to current version of the rosflight_firmware. Also the param file for the fixedwing_firmware had been changed, fixed that as well.