### PR TITLE
Interface refactor

### DIFF
--- a/rosplane/CMakeLists.txt
+++ b/rosplane/CMakeLists.txt
@@ -64,6 +64,23 @@ install(TARGETS param_manager
   INCLUDES DESTINATION include
 )
 
+# Logger
+add_library(logger
+  include/logger/logger_interface.hpp
+  include/logger/logger_ros.hpp
+  src/logger/logger_ros.cpp
+)
+ament_target_dependencies(logger rclcpp)
+ament_export_targets(logger HAS_LIBRARY_TARGET)
+install(DIRECTORY include/logger DESTINATION include)
+install(TARGETS logger
+  EXPORT logger
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+  INCLUDES DESTINATION include
+)
+
 ### START OF EXECUTABLES ###
 
 # Controller

--- a/rosplane/CMakeLists.txt
+++ b/rosplane/CMakeLists.txt
@@ -49,8 +49,9 @@ install(DIRECTORY launch params DESTINATION share/${PROJECT_NAME}/)
 
 # Param Manager
 add_library(param_manager
-  include/param_manager/param_manager.hpp
-  src/param_manager/param_manager.cpp
+  include/param_manager/param_manager_interface.hpp
+  include/param_manager/param_manager_ros.hpp
+  src/param_manager/param_manager_ros.cpp
 )
 ament_target_dependencies(param_manager rclcpp)
 ament_export_targets(param_manager HAS_LIBRARY_TARGET)

--- a/rosplane/CMakeLists.txt
+++ b/rosplane/CMakeLists.txt
@@ -90,7 +90,7 @@ add_executable(rosplane_controller
   src/controller_successive_loop.cpp
   src/controller_total_energy.cpp)
 ament_target_dependencies(rosplane_controller rosplane_msgs rosflight_msgs rclcpp rclpy Eigen3)
-target_link_libraries(rosplane_controller param_manager)
+target_link_libraries(rosplane_controller param_manager logger)
 install(TARGETS
   rosplane_controller
   DESTINATION lib/${PROJECT_NAME})
@@ -100,7 +100,7 @@ add_executable(rosplane_path_follower
   src/path_follower_example.cpp
   src/path_follower_base.cpp)
 ament_target_dependencies(rosplane_path_follower rosplane_msgs rclcpp rclpy Eigen3)
-target_link_libraries(rosplane_path_follower param_manager)
+target_link_libraries(rosplane_path_follower param_manager logger)
 install(TARGETS
   rosplane_path_follower
   DESTINATION lib/${PROJECT_NAME})
@@ -110,7 +110,7 @@ add_executable(rosplane_path_manager
   src/path_manager_base.cpp
   src/path_manager_example.cpp)
 ament_target_dependencies(rosplane_path_manager rosplane_msgs rclcpp rclpy Eigen3)
-target_link_libraries(rosplane_path_manager param_manager)
+target_link_libraries(rosplane_path_manager param_manager logger)
 install(TARGETS
   rosplane_path_manager
   DESTINATION lib/${PROJECT_NAME})
@@ -120,6 +120,7 @@ add_executable(rosplane_path_planner
   src/path_planner.cpp)
 target_link_libraries(rosplane_path_planner
   param_manager
+  logger
   ${YAML_CPP_LIBRARIES}
 )
 ament_target_dependencies(rosplane_path_planner rosplane_msgs rosflight_msgs std_srvs rclcpp rclpy Eigen3)
@@ -136,7 +137,7 @@ target_link_libraries(rosplane_estimator_node
   ${YAML_CPP_LIBRARIES}
 )
 ament_target_dependencies(rosplane_estimator_node rosplane_msgs rosflight_msgs rclcpp Eigen3)
-target_link_libraries(rosplane_estimator_node param_manager)
+target_link_libraries(rosplane_estimator_node param_manager logger)
 install(TARGETS
   rosplane_estimator_node
   DESTINATION lib/${PROJECT_NAME})

--- a/rosplane/include/controller_base.hpp
+++ b/rosplane/include/controller_base.hpp
@@ -15,7 +15,7 @@
 #include <rclcpp/rclcpp.hpp>
 #include <rosflight_msgs/msg/command.hpp>
 
-#include "param_manager.hpp"
+#include "param_manager_ros.hpp"
 #include "rosplane_msgs/msg/controller_commands.hpp"
 #include "rosplane_msgs/msg/controller_internals.hpp"
 #include "rosplane_msgs/msg/state.hpp"
@@ -101,7 +101,7 @@ protected:
   /**
    * Parameter manager object. Contains helper functions to interface parameters with ROS.
   */
-  ParamManager params_;
+  ParamManagerROS params_;
 
   /**
    * Interface for control algorithm.

--- a/rosplane/include/estimator_continuous_discrete.hpp
+++ b/rosplane/include/estimator_continuous_discrete.hpp
@@ -1,13 +1,11 @@
 #ifndef ESTIMATOR_CONTINUOUS_DISCRETE_H
 #define ESTIMATOR_CONTINUOUS_DISCRETE_H
 
-#include <math.h>
-
 #include <Eigen/Geometry>
-#include <yaml-cpp/yaml.h>
 
 #include "estimator_ekf.hpp"
-#include "estimator_ros.hpp"
+#include "param_manager/param_manager_interface.hpp"
+#include "logger/logger_interface.hpp"
 
 namespace rosplane
 {
@@ -15,11 +13,10 @@ namespace rosplane
 class EstimatorContinuousDiscrete : public EstimatorEKF
 {
 public:
-  EstimatorContinuousDiscrete();
-  EstimatorContinuousDiscrete(bool use_params);
+  EstimatorContinuousDiscrete(ParamMangerInterface * params, LoggerInterface * logger);
 
 private:
-  virtual void estimate(const Input & input, Output & output);
+  void estimate(const Input & input, Output & output) override;
 
   double lpf_a_;
   float alpha_;
@@ -138,6 +135,9 @@ private:
    * @brief Initializes the state covariance matrix with the ROS2 parameters
    */
   void initialize_state_covariances();
+
+  ParamMangerInterface * params_;
+  LoggerInterface * logger_;
 };
 
 } // namespace rosplane

--- a/rosplane/include/estimator_ekf.hpp
+++ b/rosplane/include/estimator_ekf.hpp
@@ -8,17 +8,17 @@
 #include <Eigen/Geometry>
 #include <yaml-cpp/yaml.h>
 
-#include "estimator_ros.hpp"
+#include "estimator_interface.hpp"
+#include "param_manager/param_manager_interface.hpp"
 
 namespace rosplane
 {
 
-class EstimatorEKF : public EstimatorROS
+class EstimatorEKF : public EstimatorInterface
 {
 public:
-  EstimatorEKF();
+  EstimatorEKF(ParamMangerInterface * params);
 
-protected:
   std::tuple<Eigen::MatrixXf, Eigen::VectorXf> measurement_update(
     Eigen::VectorXf x, Eigen::VectorXf inputs,
     std::function<Eigen::VectorXf(const Eigen::VectorXf, const Eigen::VectorXf)> measurement_model,
@@ -41,7 +41,8 @@ protected:
                             Eigen::VectorXf x, Eigen::MatrixXf P);
 
 private:
-  virtual void estimate(const Input & input, Output & output) override = 0;
+  ParamMangerInterface * params_;
+
 };
 
 } // namespace rosplane

--- a/rosplane/include/estimator_interface.hpp
+++ b/rosplane/include/estimator_interface.hpp
@@ -1,0 +1,55 @@
+#ifndef ESTIMATOR_INTERFACE_HPP
+#define ESTIMATOR_INTERFACE_HPP
+
+namespace rosplane
+{
+class EstimatorInterface
+{
+public:
+  virtual ~EstimatorInterface() = default;
+
+  struct Input
+  {
+    float gyro_x;
+    float gyro_y;
+    float gyro_z;
+    float accel_x;
+    float accel_y;
+    float accel_z;
+    float static_pres;
+    float diff_pres;
+    bool gps_new;
+    float gps_n;
+    float gps_e;
+    float gps_h;
+    float gps_Vg;
+    float gps_course;
+    bool status_armed;
+    bool armed_init;
+  };
+
+  struct Output
+  {
+    float pn;
+    float pe;
+    float h;
+    float va;
+    float alpha;
+    float beta;
+    float phi;
+    float theta;
+    float psi;
+    float chi;
+    float p;
+    float q;
+    float r;
+    float Vg;
+    float wn;
+    float we;
+  };
+
+  virtual void estimate(const Input & input, Output & output) = 0;
+};
+} // namespace rosplane
+
+#endif //ESTIMATOR_INTERFACE_HPP

--- a/rosplane/include/estimator_ros.hpp
+++ b/rosplane/include/estimator_ros.hpp
@@ -23,7 +23,7 @@
 #include <sensor_msgs/msg/nav_sat_fix.hpp>
 #include <yaml-cpp/yaml.h>
 
-#include "param_manager.hpp"
+#include "param_manager_ros.hpp"
 #include "rosplane_msgs/msg/state.hpp"
 
 #define EARTH_RADIUS 6378145.0f
@@ -84,7 +84,7 @@ protected:
 
   virtual void estimate(const Input & input, Output & output) = 0;
 
-  ParamManager params_;
+  ParamManagerROS params_;
   bool gps_init_;
   double init_lat_ = 0.0; /**< Initial latitude in degrees */
   double init_lon_ = 0.0; /**< Initial longitude in degrees */

--- a/rosplane/include/logger/logger_interface.hpp
+++ b/rosplane/include/logger/logger_interface.hpp
@@ -1,0 +1,25 @@
+//
+// Created by brandon on 7/18/24.
+//
+
+#ifndef LOGGER_INTERFACE_HPP
+#define LOGGER_INTERFACE_HPP
+
+#include <sstream>
+
+namespace rosplane
+{
+class LoggerInterface
+{
+public:
+  virtual ~LoggerInterface() = default;
+
+  virtual void debug(const std::stringstream& message) = 0;
+  virtual void info(const std::stringstream& message) = 0;
+  virtual void warn(const std::stringstream& message) = 0;
+  virtual void error(const std::stringstream& message) = 0;
+  virtual void fatal(const std::stringstream& message) = 0;
+};
+}
+
+#endif //LOGGER_INTERFACE_HPP

--- a/rosplane/include/logger/logger_interface.hpp
+++ b/rosplane/include/logger/logger_interface.hpp
@@ -1,11 +1,7 @@
-//
-// Created by brandon on 7/18/24.
-//
-
 #ifndef LOGGER_INTERFACE_HPP
 #define LOGGER_INTERFACE_HPP
 
-#include <sstream>
+#include <string>
 
 namespace rosplane
 {
@@ -14,11 +10,11 @@ class LoggerInterface
 public:
   virtual ~LoggerInterface() = default;
 
-  virtual void debug(const std::stringstream& message) = 0;
-  virtual void info(const std::stringstream& message) = 0;
-  virtual void warn(const std::stringstream& message) = 0;
-  virtual void error(const std::stringstream& message) = 0;
-  virtual void fatal(const std::stringstream& message) = 0;
+  virtual void debug(const std::string & message) = 0;
+  virtual void info(const std::string & message) = 0;
+  virtual void warn(const std::string & message) = 0;
+  virtual void error(const std::string & message) = 0;
+  virtual void fatal(const std::string & message) = 0;
 };
 }
 

--- a/rosplane/include/logger/logger_ros.hpp
+++ b/rosplane/include/logger/logger_ros.hpp
@@ -1,7 +1,3 @@
-//
-// Created by brandon on 7/18/24.
-//
-
 #ifndef LOGGER_ROS_HPP
 #define LOGGER_ROS_HPP
 
@@ -16,11 +12,11 @@ class LoggerROS : public LoggerInterface
 public:
   LoggerROS(rclcpp::Node & node);
 
-  void debug(const std::stringstream& message) override;
-  void info(const std::stringstream& message) override;
-  void warn(const std::stringstream& message) override;
-  void error(const std::stringstream& message) override;
-  void fatal(const std::stringstream& message) override;
+  void debug(const std::string& message) override;
+  void info(const std::string& message) override;
+  void warn(const std::string& message) override;
+  void error(const std::string& message) override;
+  void fatal(const std::string& message) override;
 
 private:
   rclcpp::Node & node_;

--- a/rosplane/include/logger/logger_ros.hpp
+++ b/rosplane/include/logger/logger_ros.hpp
@@ -1,0 +1,30 @@
+//
+// Created by brandon on 7/18/24.
+//
+
+#ifndef LOGGER_ROS_HPP
+#define LOGGER_ROS_HPP
+
+#include <rclcpp/rclcpp.hpp>
+
+#include "logger_interface.hpp"
+
+namespace rosplane
+{
+class LoggerROS : public LoggerInterface
+{
+public:
+  LoggerROS(rclcpp::Node & node);
+
+  void debug(const std::stringstream& message) override;
+  void info(const std::stringstream& message) override;
+  void warn(const std::stringstream& message) override;
+  void error(const std::stringstream& message) override;
+  void fatal(const std::stringstream& message) override;
+
+private:
+  rclcpp::Node & node_;
+};
+} // namespace rosplane
+
+#endif //LOGGER_ROS_HPP

--- a/rosplane/include/param_manager/param_manager_interface.hpp
+++ b/rosplane/include/param_manager/param_manager_interface.hpp
@@ -1,125 +1,93 @@
-/**
- * @file param_manager.hpp
- * 
- * Manager for the parameters in ROSplane. Includes helper functions to set and get parameters
- * 
- * @author Jacob Moore <jacobmoor2@gmail.com>
-*/
+#ifndef PARAM_MANAGER_INTERFACE_HPP
+#define PARAM_MANAGER_INTERFACE_HPP
 
-#ifndef PARAM_MANAGER_H
-#define PARAM_MANAGER_H
-
-#include <variant>
-
-#include <rclcpp/rclcpp.hpp>
+#include <string>
 
 namespace rosplane
 {
-
-class ParamManager
+class ParamMangerInterface
 {
 public:
-  /**
-   * Public constructor
-   * 
-   * @param node: the ROS2 node that has this parameter object. Used to poll the ROS2 parameters
-  */
-  ParamManager(rclcpp::Node * node);
+  virtual ~ParamMangerInterface() = default;
 
   /**
    * Helper function to access parameter values of type double stored in param_manager object
    * @return Double value of the parameter
-  */
-  double get_double(std::string param_name);
+   */
+  virtual double get_double(std::string param_name) = 0;
 
   /**
    * Helper function to access parameter values of type bool stored in param_manager object
    * @return Bool value of the parameter
-  */
-  bool get_bool(std::string param_name);
+   */
+  virtual bool get_bool(std::string param_name) = 0;
 
   /**
    * Helper function to access parameter values of type integer stored in param_manager object
    * @return Integer value of the parameter
-  */
-  int64_t get_int(std::string param_name);
+   */
+  virtual int64_t get_int(std::string param_name) = 0;
 
   /**
    * Helper function to access parameter values of type string stored in param_manager object
    * @return String value of the parameter
-  */
-  std::string get_string(std::string param_name);
+   */
+  virtual std::string get_string(std::string param_name) = 0;
 
   /**
    * Helper function to declare parameters in the param_manager object
    * Inserts a parameter into the parameter object and declares it with the ROS system
-  */
-  void declare_double(std::string param_name, double value);
+   */
+  virtual void declare_double(std::string param_name, double value) = 0;
 
   /**
    * Helper function to declare parameters in the param_manager object
    * Inserts a parameter into the parameter object and declares it with the ROS system
-  */
-  void declare_bool(std::string param_name, bool value);
+   */
+  virtual void declare_bool(std::string param_name, bool value) = 0;
 
   /**
    * Helper function to declare parameters in the param_manager object
    * Inserts a parameter into the parameter object and declares it with the ROS system
-  */
-  void declare_int(std::string param_name, int64_t value);
+   */
+  virtual void declare_int(std::string param_name, int64_t value) = 0;
 
   /**
    * Helper function to declare parameters in the param_manager object
    * Inserts a parameter into the parameter object and declares it with the ROS system
-  */
-  void declare_string(std::string param_name, std::string value);
+   */
+  virtual void declare_string(std::string param_name, std::string value) = 0;
 
   /**
    * This sets the parameters with the values in the params_ object from the supplied parameter file, or sets them to
    * the default if no value is given for a parameter.
    */
-  void set_parameters();
+  virtual void set_parameters() = 0;
 
   /**
    * This function sets a previously declared parameter to a new value in both the parameter object
    * and the ROS system.
    */
-  void set_double(std::string param_name, double value);
+  virtual void set_double(std::string param_name, double value) = 0;
 
   /**
    * This function sets a previously declared parameter to a new value in both the parameter object
    * and the ROS system.
    */
-  void set_bool(std::string param_name, bool value);
+  virtual void set_bool(std::string param_name, bool value) = 0;
 
   /**
    * This function sets a previously declared parameter to a new value in both the parameter object
    * and the ROS system.
    */
-  void set_int(std::string param_name, int64_t value);
+  virtual void set_int(std::string param_name, int64_t value) = 0;
 
   /**
    * This function sets a previously declared parameter to a new value in both the parameter object
    * and the ROS system.
    */
-  void set_string(std::string param_name, std::string value);
-
-  /**
-   * This function should be called in the parametersCallback function in a containing ROS node.
-   * It takes in a vector of changed parameters and updates them within the params_ object.
-   * 
-   * @param parameters: Vector of ROS Parameter objects that have been changed. 
-   * @returns Boolean value corresponding to success or failure of the parameter changes
-  */
-  bool set_parameters_callback(const std::vector<rclcpp::Parameter> & parameters);
-
-private:
-  /**
-   * Data structure to hold all of the parameters
-  */
-  std::map<std::string, std::variant<double, bool, int64_t, std::string>> params_;
-  rclcpp::Node * container_node_;
+  virtual void set_string(std::string param_name, std::string value) = 0;
 };
-
 } // namespace rosplane
-#endif // PARAM_MANAGER_H
+
+#endif //PARAM_MANAGER_INTERFACE_HPP

--- a/rosplane/include/param_manager/param_manager_ros.hpp
+++ b/rosplane/include/param_manager/param_manager_ros.hpp
@@ -1,0 +1,126 @@
+/**
+ * @file param_manager_ros.hpp
+ * 
+ * Manager for the parameters in ROSplane. Includes helper functions to set and get parameters
+ * 
+ * @author Jacob Moore <jacobmoor2@gmail.com>
+*/
+
+#ifndef PARAM_MANAGER_H
+#define PARAM_MANAGER_H
+
+#include <variant>
+
+#include <rclcpp/rclcpp.hpp>
+
+#include "param_manager_interface.hpp"
+
+namespace rosplane
+{
+class ParamManagerROS : public ParamMangerInterface
+{
+public:
+  /**
+   * Public constructor
+   * 
+   * @param node: the ROS2 node that has this parameter object. Used to poll the ROS2 parameters
+  */
+  ParamManagerROS(rclcpp::Node * node);
+
+  /**
+   * Helper function to access parameter values of type double stored in param_manager object
+   * @return Double value of the parameter
+  */
+  double get_double(std::string param_name);
+
+  /**
+   * Helper function to access parameter values of type bool stored in param_manager object
+   * @return Bool value of the parameter
+  */
+  bool get_bool(std::string param_name);
+
+  /**
+   * Helper function to access parameter values of type integer stored in param_manager object
+   * @return Integer value of the parameter
+  */
+  int64_t get_int(std::string param_name);
+
+  /**
+   * Helper function to access parameter values of type string stored in param_manager object
+   * @return String value of the parameter
+  */
+  std::string get_string(std::string param_name);
+
+  /**
+   * Helper function to declare parameters in the param_manager object
+   * Inserts a parameter into the parameter object and declares it with the ROS system
+  */
+  void declare_double(std::string param_name, double value);
+
+  /**
+   * Helper function to declare parameters in the param_manager object
+   * Inserts a parameter into the parameter object and declares it with the ROS system
+  */
+  void declare_bool(std::string param_name, bool value);
+
+  /**
+   * Helper function to declare parameters in the param_manager object
+   * Inserts a parameter into the parameter object and declares it with the ROS system
+  */
+  void declare_int(std::string param_name, int64_t value);
+
+  /**
+   * Helper function to declare parameters in the param_manager object
+   * Inserts a parameter into the parameter object and declares it with the ROS system
+  */
+  void declare_string(std::string param_name, std::string value);
+
+  /**
+   * This sets the parameters with the values in the params_ object from the supplied parameter file, or sets them to
+   * the default if no value is given for a parameter.
+   */
+  void set_parameters();
+
+  /**
+   * This function sets a previously declared parameter to a new value in both the parameter object
+   * and the ROS system.
+   */
+  void set_double(std::string param_name, double value);
+
+  /**
+   * This function sets a previously declared parameter to a new value in both the parameter object
+   * and the ROS system.
+   */
+  void set_bool(std::string param_name, bool value);
+
+  /**
+   * This function sets a previously declared parameter to a new value in both the parameter object
+   * and the ROS system.
+   */
+  void set_int(std::string param_name, int64_t value);
+
+  /**
+   * This function sets a previously declared parameter to a new value in both the parameter object
+   * and the ROS system.
+   */
+  void set_string(std::string param_name, std::string value);
+
+  /**
+   * This function should be called in the parametersCallback function in a containing ROS node.
+   * It takes in a vector of changed parameters and updates them within the params_ object.
+   * 
+   * @param parameters: Vector of ROS Parameter objects that have been changed. 
+   * @returns Boolean value corresponding to success or failure of the parameter changes
+  */
+  bool set_parameters_callback(const std::vector<rclcpp::Parameter> & parameters);
+
+private:
+  /**
+   * Data structure to hold all of the parameters
+  */
+  std::map<std::string, std::variant<double, bool, int64_t, std::string>> params_;
+  rclcpp::Node * container_node_;
+};
+
+} // namespace rosplane
+#endif // PARAM_MANAGER_H

--- a/rosplane/include/path_follower_base.hpp
+++ b/rosplane/include/path_follower_base.hpp
@@ -3,7 +3,7 @@
 
 #include <rclcpp/rclcpp.hpp>
 
-#include "param_manager.hpp"
+#include "param_manager_ros.hpp"
 #include "rosplane_msgs/msg/controller_commands.hpp"
 #include "rosplane_msgs/msg/current_path.hpp"
 #include "rosplane_msgs/msg/state.hpp"
@@ -54,7 +54,7 @@ protected:
 
   virtual void follow(const Input & input, Output & output) = 0;
 
-  ParamManager params_;
+  ParamManagerROS params_;
 
 private:
   /**

--- a/rosplane/include/path_manager_base.hpp
+++ b/rosplane/include/path_manager_base.hpp
@@ -13,7 +13,7 @@
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/fluid_pressure.hpp>
 
-#include "param_manager.hpp"
+#include "param_manager_ros.hpp"
 #include "rosplane_msgs/msg/current_path.hpp"
 #include "rosplane_msgs/msg/state.hpp"
 #include "rosplane_msgs/msg/waypoint.hpp"
@@ -63,7 +63,7 @@ protected:
     int8_t lamda; /** Direction of orbital path (cw is 1, ccw is -1) */
   };
 
-  ParamManager params_; /** Holds the parameters for the path_manager and children */
+  ParamManagerROS params_; /** Holds the parameters for the path_manager and children */
 
   /**
    * @brief Manages the current path based on the stored waypoint list

--- a/rosplane/include/path_planner.hpp
+++ b/rosplane/include/path_planner.hpp
@@ -3,7 +3,7 @@
 #include <rosflight_msgs/srv/param_file.hpp>
 #include <std_srvs/srv/trigger.hpp>
 
-#include "param_manager.hpp"
+#include "param_manager_ros.hpp"
 #include "rosplane_msgs/msg/state.hpp"
 #include "rosplane_msgs/msg/waypoint.hpp"
 #include "rosplane_msgs/srv/add_waypoint.hpp"
@@ -19,7 +19,7 @@ public:
   PathPlanner();
   ~PathPlanner();
 
-  ParamManager params_; /** Holds the parameters for the path_planner*/
+  ParamManagerROS params_; /** Holds the parameters for the path_planner*/
 
 private:
   /**

--- a/rosplane/src/estimator_ekf.cpp
+++ b/rosplane/src/estimator_ekf.cpp
@@ -9,9 +9,7 @@
 namespace rosplane
 {
 
-EstimatorEKF::EstimatorEKF()
-    : EstimatorROS()
-{}
+EstimatorEKF::EstimatorEKF(ParamMangerInterface * params) : params_(params) {}
 
 std::tuple<Eigen::MatrixXf, Eigen::VectorXf> EstimatorEKF::measurement_update(
   Eigen::VectorXf x, Eigen::VectorXf inputs,
@@ -51,7 +49,7 @@ std::tuple<Eigen::MatrixXf, Eigen::VectorXf> EstimatorEKF::propagate_model(
 {
 
   int N =
-    params_.get_int("num_propagation_steps"); // TODO: Declare this parameter in the ekf class.
+    params_->get_int("num_propagation_steps"); // TODO: Declare this parameter in the ekf class.
 
   for (int _ = 0; _ < N; _++) {
 

--- a/rosplane/src/logger/logger_ros.cpp
+++ b/rosplane/src/logger/logger_ros.cpp
@@ -1,0 +1,36 @@
+//
+// Created by brandon on 7/18/24.
+//
+
+#include "logger/logger_ros.hpp"
+
+namespace rosplane
+{
+ LoggerROS::LoggerROS(rclcpp::Node & node) : node_(node) {}
+
+void LoggerROS::debug(const std::stringstream& message)
+{
+  RCLCPP_DEBUG_STREAM(node_.get_logger(), message.str());
+}
+
+void LoggerROS::info(const std::stringstream & message)
+{
+  RCLCPP_INFO_STREAM(node_.get_logger(), message.str());
+}
+
+void LoggerROS::warn(const std::stringstream & message)
+{
+  RCLCPP_WARN_STREAM(node_.get_logger(), message.str());
+}
+
+void LoggerROS::error(const std::stringstream & message)
+{
+  RCLCPP_ERROR_STREAM(node_.get_logger(), message.str());
+}
+
+void LoggerROS::fatal(const std::stringstream & message)
+{
+  RCLCPP_FATAL_STREAM(node_.get_logger(), message.str());
+}
+
+} // namespace rosplane

--- a/rosplane/src/logger/logger_ros.cpp
+++ b/rosplane/src/logger/logger_ros.cpp
@@ -1,36 +1,32 @@
-//
-// Created by brandon on 7/18/24.
-//
-
 #include "logger/logger_ros.hpp"
 
 namespace rosplane
 {
  LoggerROS::LoggerROS(rclcpp::Node & node) : node_(node) {}
 
-void LoggerROS::debug(const std::stringstream& message)
+void LoggerROS::debug(const std::string& message)
 {
-  RCLCPP_DEBUG_STREAM(node_.get_logger(), message.str());
+  RCLCPP_DEBUG_STREAM(node_.get_logger(), message);
 }
 
-void LoggerROS::info(const std::stringstream & message)
+void LoggerROS::info(const std::string& message)
 {
-  RCLCPP_INFO_STREAM(node_.get_logger(), message.str());
+  RCLCPP_INFO_STREAM(node_.get_logger(), message);
 }
 
-void LoggerROS::warn(const std::stringstream & message)
+void LoggerROS::warn(const std::string& message)
 {
-  RCLCPP_WARN_STREAM(node_.get_logger(), message.str());
+  RCLCPP_WARN_STREAM(node_.get_logger(), message);
 }
 
-void LoggerROS::error(const std::stringstream & message)
+void LoggerROS::error(const std::string & message)
 {
-  RCLCPP_ERROR_STREAM(node_.get_logger(), message.str());
+  RCLCPP_ERROR_STREAM(node_.get_logger(), message);
 }
 
-void LoggerROS::fatal(const std::stringstream & message)
+void LoggerROS::fatal(const std::string & message)
 {
-  RCLCPP_FATAL_STREAM(node_.get_logger(), message.str());
+  RCLCPP_FATAL_STREAM(node_.get_logger(), message);
 }
 
 } // namespace rosplane

--- a/rosplane/src/param_manager/param_manager_ros.cpp
+++ b/rosplane/src/param_manager/param_manager_ros.cpp
@@ -1,15 +1,15 @@
 #include <variant>
 
-#include "param_manager.hpp"
+#include "param_manager_ros.hpp"
 
 namespace rosplane
 {
 
-ParamManager::ParamManager(rclcpp::Node * node)
+ParamManagerROS::ParamManagerROS(rclcpp::Node * node)
     : container_node_{node}
 {}
 
-void ParamManager::declare_double(std::string param_name, double value)
+void ParamManagerROS::declare_double(std::string param_name, double value)
 {
   // Insert the parameter into the parameter struct
   params_[param_name] = value;
@@ -17,7 +17,7 @@ void ParamManager::declare_double(std::string param_name, double value)
   container_node_->declare_parameter(param_name, value);
 }
 
-void ParamManager::declare_bool(std::string param_name, bool value)
+void ParamManagerROS::declare_bool(std::string param_name, bool value)
 {
   // Insert the parameter into the parameter struct
   params_[param_name] = value;
@@ -25,7 +25,7 @@ void ParamManager::declare_bool(std::string param_name, bool value)
   container_node_->declare_parameter(param_name, value);
 }
 
-void ParamManager::declare_int(std::string param_name, int64_t value)
+void ParamManagerROS::declare_int(std::string param_name, int64_t value)
 {
   // Insert the parameter into the parameter struct
   params_[param_name] = value;
@@ -33,7 +33,7 @@ void ParamManager::declare_int(std::string param_name, int64_t value)
   container_node_->declare_parameter(param_name, value);
 }
 
-void ParamManager::declare_string(std::string param_name, std::string value)
+void ParamManagerROS::declare_string(std::string param_name, std::string value)
 {
   // Insert the parameter into the parameter struct
   params_[param_name] = value;
@@ -41,7 +41,7 @@ void ParamManager::declare_string(std::string param_name, std::string value)
   container_node_->declare_parameter(param_name, value);
 }
 
-void ParamManager::set_double(std::string param_name, double value)
+void ParamManagerROS::set_double(std::string param_name, double value)
 {
   // Check that the parameter is in the parameter struct
   if (params_.find(param_name) == params_.end()) {
@@ -56,7 +56,7 @@ void ParamManager::set_double(std::string param_name, double value)
   container_node_->set_parameter(rclcpp::Parameter(param_name, value));
 }
 
-void ParamManager::set_bool(std::string param_name, bool value)
+void ParamManagerROS::set_bool(std::string param_name, bool value)
 {
   // Check that the parameter is in the parameter struct
   if (params_.find(param_name) == params_.end()) {
@@ -71,7 +71,7 @@ void ParamManager::set_bool(std::string param_name, bool value)
   container_node_->set_parameter(rclcpp::Parameter(param_name, value));
 }
 
-void ParamManager::set_int(std::string param_name, int64_t value)
+void ParamManagerROS::set_int(std::string param_name, int64_t value)
 {
   // Check that the parameter is in the parameter struct
   if (params_.find(param_name) == params_.end()) {
@@ -86,7 +86,7 @@ void ParamManager::set_int(std::string param_name, int64_t value)
   container_node_->set_parameter(rclcpp::Parameter(param_name, value));
 }
 
-void ParamManager::set_string(std::string param_name, std::string value)
+void ParamManagerROS::set_string(std::string param_name, std::string value)
 {
   // Check that the parameter is in the parameter struct
   if (params_.find(param_name) == params_.end()) {
@@ -101,7 +101,7 @@ void ParamManager::set_string(std::string param_name, std::string value)
   container_node_->set_parameter(rclcpp::Parameter(param_name, value));
 }
 
-double ParamManager::get_double(std::string param_name)
+double ParamManagerROS::get_double(std::string param_name)
 {
   try {
     return std::get<double>(params_[param_name]);
@@ -111,7 +111,7 @@ double ParamManager::get_double(std::string param_name)
   }
 }
 
-bool ParamManager::get_bool(std::string param_name)
+bool ParamManagerROS::get_bool(std::string param_name)
 {
   try {
     return std::get<bool>(params_[param_name]);
@@ -121,7 +121,7 @@ bool ParamManager::get_bool(std::string param_name)
   }
 }
 
-int64_t ParamManager::get_int(std::string param_name)
+int64_t ParamManagerROS::get_int(std::string param_name)
 {
   try {
     return std::get<int64_t>(params_[param_name]);
@@ -131,7 +131,7 @@ int64_t ParamManager::get_int(std::string param_name)
   }
 }
 
-std::string ParamManager::get_string(std::string param_name)
+std::string ParamManagerROS::get_string(std::string param_name)
 {
   try {
     return std::get<std::string>(params_[param_name]);
@@ -141,7 +141,7 @@ std::string ParamManager::get_string(std::string param_name)
   }
 }
 
-void ParamManager::set_parameters()
+void ParamManagerROS::set_parameters()
 {
 
   // Get the parameters from the launch file, if given.
@@ -163,7 +163,7 @@ void ParamManager::set_parameters()
   }
 }
 
-bool ParamManager::set_parameters_callback(const std::vector<rclcpp::Parameter> & parameters)
+bool ParamManagerROS::set_parameters_callback(const std::vector<rclcpp::Parameter> & parameters)
 {
   // Check each parameter in the incoming vector of parameters to change, and change the appropriate parameter.
   for (const auto & param : parameters) {

--- a/rosplane/src/path_planner.cpp
+++ b/rosplane/src/path_planner.cpp
@@ -9,7 +9,7 @@
 #include <std_srvs/srv/trigger.hpp>
 #include <yaml-cpp/yaml.h>
 
-#include "param_manager.hpp"
+#include "param_manager_ros.hpp"
 #include "rosplane_msgs/msg/state.hpp"
 #include "rosplane_msgs/msg/waypoint.hpp"
 #include "rosplane_msgs/srv/add_waypoint.hpp"

--- a/rosplane_extra/include/input_mapper.hpp
+++ b/rosplane_extra/include/input_mapper.hpp
@@ -6,7 +6,7 @@
 #include <rosflight_msgs/msg/rc_raw.hpp>
 #include <std_srvs/srv/trigger.hpp>
 
-#include "param_manager/param_manager.hpp"
+#include "param_manager/param_manager_ros.hpp"
 #include "rosplane_msgs/msg/controller_commands.hpp"
 #include "rosplane_msgs/msg/state.hpp"
 
@@ -239,7 +239,7 @@ private:
   /**
    * Param manager object, for getting parameters from ROS.
    */
-  ParamManager params_;
+  ParamManagerROS params_;
 
   /**
    * ROS2 parameter system interface. This connects ROS2 parameters with the defined update callback,


### PR DESCRIPTION
This is a refactor of is-a to has-a for the relationship between ROSplane and ROS for the estimator. The remaining nodes still need to be done. This make the relationship between ROS and the estimator more clear and better separates ROS from the estimator, allowing for estimator development outside of a ROS environment and making it easier to keep the classes separate from each other (like those parameters owned by the ROS class being used two inheritances down, which I changed).