### PR TITLE
Fixed error handling for ParamManager::get_double

### DIFF
--- a/rosplane/src/ekf/estimator_ros.cpp
+++ b/rosplane/src/ekf/estimator_ros.cpp
@@ -336,19 +336,17 @@ int main(int argc, char ** argv)
   char* use_params;
   if (argc >= 2) {
     use_params = argv[1];
+    if (!strcmp(use_params, "true")) {
+      rclcpp::spin(std::make_shared<rosplane::EstimatorContinuousDiscrete>(use_params));
+    } else if (strcmp(use_params, "false")) // If the string is not true or false print error.
+    {
+      auto estimator_node = std::make_shared<rosplane::EstimatorContinuousDiscrete>();
+      RCLCPP_WARN(estimator_node->get_logger(),
+                  "Invalid option for seeding estimator, defaulting to unseeded.");
+      rclcpp::spin(estimator_node);
+    } else {
+      rclcpp::spin(std::make_shared<rosplane::EstimatorContinuousDiscrete>());
+    }
   }
-
-  if (!strcmp(use_params, "true")) {
-    rclcpp::spin(std::make_shared<rosplane::EstimatorContinuousDiscrete>(use_params));
-  } else if (strcmp(use_params, "false")) // If the string is not true or false print error.
-  {
-    auto estimator_node = std::make_shared<rosplane::EstimatorContinuousDiscrete>();
-    RCLCPP_WARN(estimator_node->get_logger(),
-                "Invalid option for seeding estimator, defaulting to unseeded.");
-    rclcpp::spin(estimator_node);
-  } else {
-    rclcpp::spin(std::make_shared<rosplane::EstimatorContinuousDiscrete>());
-  }
-
   return 0;
 }

--- a/rosplane/src/param_manager/param_manager.cpp
+++ b/rosplane/src/param_manager/param_manager.cpp
@@ -145,12 +145,9 @@ double ParamManager::get_double(std::string param_name)
   try {
     auto param = params_.at(param_name);
     return std::get<double>(param);
-  } catch (std::bad_variant_access & e) {
+  } catch (std::exception & e) {
     RCLCPP_ERROR_STREAM(container_node_->get_logger(), "ERROR GETTING PARAMETER: " + param_name);
     throw std::runtime_error(e.what());
-  } catch(std::out_of_range& e){
-      RCLCPP_ERROR_STREAM(container_node_->get_logger(), "ERROR GETTING PARAMETER: " + param_name);
-      throw std::runtime_error(e.what());
   }
 }
 

--- a/rosplane/src/param_manager/param_manager.cpp
+++ b/rosplane/src/param_manager/param_manager.cpp
@@ -143,10 +143,14 @@ void ParamManager::set_string(std::string param_name, std::string value)
 double ParamManager::get_double(std::string param_name)
 {
   try {
-    return std::get<double>(params_[param_name]);
+    auto param = params_.at(param_name);
+    return std::get<double>(param);
   } catch (std::bad_variant_access & e) {
     RCLCPP_ERROR_STREAM(container_node_->get_logger(), "ERROR GETTING PARAMETER: " + param_name);
     throw std::runtime_error(e.what());
+  }catch(std::out_of_range& e){
+      RCLCPP_ERROR_STREAM(container_node_->get_logger(), "ERROR GETTING PARAMETER: " + param_name);
+      throw std::runtime_error(e.what());
   }
 }
 

--- a/rosplane/src/param_manager/param_manager.cpp
+++ b/rosplane/src/param_manager/param_manager.cpp
@@ -148,7 +148,7 @@ double ParamManager::get_double(std::string param_name)
   } catch (std::bad_variant_access & e) {
     RCLCPP_ERROR_STREAM(container_node_->get_logger(), "ERROR GETTING PARAMETER: " + param_name);
     throw std::runtime_error(e.what());
-  }catch(std::out_of_range& e){
+  } catch(std::out_of_range& e){
       RCLCPP_ERROR_STREAM(container_node_->get_logger(), "ERROR GETTING PARAMETER: " + param_name);
       throw std::runtime_error(e.what());
   }


### PR DESCRIPTION
Fixed error handling for ParamManager::get_double.

There are three possible cases:

1. The key exists and the variant type is a double.
2. The key exists but the variant type is not a double.
3. The key does not exist.

`auto param = params_.at(param_name);`ensures that the key exists before calling `std::get<double>` 

This stops a new key being inserted and the value being zero initialised to a double.

An extra catch has been added to catch the `std::out_of_range` exception that is thrown if the key is out of bounds.