### PR TITLE
fix: necessary depencency for Jazzy

### DIFF
--- a/rosplane/CMakeLists.txt
+++ b/rosplane/CMakeLists.txt
@@ -117,7 +117,7 @@ add_executable(estimator
 target_link_libraries(estimator
   ${YAML_CPP_LIBRARIES}
 )
-ament_target_dependencies(estimator rosplane_msgs rosflight_msgs rclcpp Eigen3)
+ament_target_dependencies(estimator rosplane_msgs rosflight_msgs rclcpp Eigen3 ament_index_cpp)
 target_link_libraries(estimator param_manager)
 install(TARGETS
   estimator

--- a/rosplane_gcs/CMakeLists.txt
+++ b/rosplane_gcs/CMakeLists.txt
@@ -34,14 +34,7 @@ install(DIRECTORY launch config resource DESTINATION share/${PROJECT_NAME})
 # Publisher node executable
 add_executable(rviz_waypoint_publisher
                src/rviz_waypoint_publisher.cpp)
-ament_target_dependencies(rviz_waypoint_publisher
-  ament_index_cpp
-  rosplane_msgs
-  visualization_msgs
-  rclcpp
-  tf2
-  tf2_ros
-  geometry_msgs)
+ament_target_dependencies(rviz_waypoint_publisher ament_index_cpp rosplane_msgs visualization_msgs rclcpp tf2 tf2_ros geometry_msgs)
 install(TARGETS 
   rviz_waypoint_publisher
   DESTINATION lib/${PROJECT_NAME})

--- a/rosplane_gcs/CMakeLists.txt
+++ b/rosplane_gcs/CMakeLists.txt
@@ -34,7 +34,14 @@ install(DIRECTORY launch config resource DESTINATION share/${PROJECT_NAME})
 # Publisher node executable
 add_executable(rviz_waypoint_publisher
                src/rviz_waypoint_publisher.cpp)
-ament_target_dependencies(rviz_waypoint_publisher rosplane_msgs visualization_msgs rclcpp tf2 tf2_ros geometry_msgs)
+ament_target_dependencies(rviz_waypoint_publisher
+  ament_index_cpp
+  rosplane_msgs
+  visualization_msgs
+  rclcpp
+  tf2
+  tf2_ros
+  geometry_msgs)
 install(TARGETS 
   rviz_waypoint_publisher
   DESTINATION lib/${PROJECT_NAME})


### PR DESCRIPTION
An installation path has changed for Jazzy, including it with `ament_target_dependencies` is necessary to compile: https://github.com/ament/ament_index/issues/84
